### PR TITLE
Add matrixStats to install-packages.R

### DIFF
--- a/scripts/install-packages.R
+++ b/scripts/install-packages.R
@@ -10,7 +10,8 @@ cran_packages <- c("remotes",
                    "palmerpenguins",
                    "rmarkdown",
                    "BiocManager",
-                   "tidyverse")
+                   "tidyverse",
+                   "matrixStats")
 install.packages(cran_packages)
 
 # Bioconductor


### PR DESCRIPTION
I needed to install `matrixStats` in the RStudio Cloud project after running `install-packages.R` so clearly it was missing!